### PR TITLE
Resolve .gitignore conflict and add CLAUDE.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,7 +209,6 @@ testoutput/
 
 \.idea/
 
-<<<<<<< HEAD
 KSLTesting/gradle/wrapper/
 
 KSLExtensions/gradle/wrapper/
@@ -219,27 +218,6 @@ KSLCore/gradle/wrapper/
 KSLExampleProject/gradle/wrapper/
 
 KSLExamples/gradle/wrapper/
-=======
-KSLCore/gradle/wrapper/gradle-wrapper.jar
-
-KSLCore/gradle/wrapper/gradle-wrapper.properties
-
-KSLExamples/gradle/wrapper/gradle-wrapper.jar
-
-KSLExamples/gradle/wrapper/gradle-wrapper.properties
-
-KSLExtensions/gradle/wrapper/gradle-wrapper.jar
-
-KSLExtensions/gradle/wrapper/gradle-wrapper.properties
-
-KSLTesting/gradle/wrapper/gradle-wrapper.jar
-
-KSLTesting/gradle/wrapper/gradle-wrapper.properties
-
-KSLExampleProject/gradle/wrapper/gradle-wrapper.jar
-
-KSLExampleProject/gradle/wrapper/gradle-wrapper.properties
->>>>>>> develop
 
 JSLKotlin/gradle/wrapper/gradle-wrapper.jar
 JSLKotlin/gradle/wrapper/gradle-wrapper.properties
@@ -264,3 +242,7 @@ KSLProjectTemplate/gradle/wrapper/gradle-wrapper.jar
 KSLProjectTemplate/gradle/wrapper/gradle-wrapper.properties
 *.hprof
 *.wal
+
+# Claude Code
+CLAUDE.md
+.claude/


### PR DESCRIPTION
## Summary
- Resolved a pre-existing merge conflict in `.gitignore` (HEAD vs develop), keeping directory-level `gradle/wrapper/` ignores
- Added `CLAUDE.md` and `.claude/` to `.gitignore` so Claude Code artifacts are never accidentally committed
- Created `CLAUDE.md` with build commands, module structure, project overview, tech stack, architecture, and coding rules for Claude Code instances working in this repo

## Test plan
- [ ] Verify `.gitignore` no longer has conflict markers
- [ ] Verify `CLAUDE.md` is present at repo root and not tracked by git
- [ ] Verify `.claude/` directory is not tracked by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)